### PR TITLE
Passing example GainPluginAudioProcessor by reference

### DIFF
--- a/examples/GainPlugin/Source/PluginProcessor.cpp
+++ b/examples/GainPlugin/Source/PluginProcessor.cpp
@@ -197,7 +197,7 @@ AudioProcessorEditor* GainPluginAudioProcessor::createEditor()
     File sourceDir = File(__FILE__).getParentDirectory();
     File bundle = sourceDir.getChildFile("jsui/build/js/main.js");
 
-    auto* editor = new blueprint::BlueprintGenericEditor(this, bundle, &params);
+    auto* editor = new blueprint::BlueprintGenericEditor(*this, bundle, &params);
 
     editor->setResizable(true, true);
     editor->setResizeLimits(400, 240, 400 * 2, 240 * 2);


### PR DESCRIPTION
I was getting this error when trying to compile the example GainPlugin:

PluginProcessor.cpp
Error:(200, 24) no matching constructor for initialization of 'blueprint::BlueprintGenericEditor'
Note:(33, 9) candidate constructor not viable: no known conversion from 'GainPluginAudioProcessor *' to 'juce::AudioProcessor &' for 1st argument; dereference the argument with *
Note:(65, 55) candidate constructor not viable: requires 1 argument, but 3 were provided

On line 200 of PluginProcessor.cpp seems like the GainPluginAudioProcessor is being passed by pointer (this) to the BlueprintGenericEditor, which wants a reference. Fixed this by changing line 200 (the Github diff seems to have gone weird here, that's the only change in this commit):

auto* editor = new blueprint::BlueprintGenericEditor(*this, bundle, &params);

Maybe I've misinterpreted something? But that's how I got the gain plugin example working so thought I'd submit it
