### PR TITLE
Fix a bug with canvas resize performance in the standard non-stateful

### DIFF
--- a/react_juce/core/CanvasView.cpp
+++ b/react_juce/core/CanvasView.cpp
@@ -611,6 +611,11 @@ namespace reactjuce
             if (!shouldAnimate && isTimerRunning())
                 stopTimer();
         }
+        
+        if (name == statefulProp && props[statefulProp])
+        {
+            resized();
+        }
     }
 
     //==============================================================================
@@ -652,15 +657,18 @@ namespace reactjuce
     {
         View::resized();
 
-        //TODO: Fix image scalling for retina displays.
-        //      May require passing an optional scaleFactor
-        //      arg through to draw commands.
-        const auto bounds = getLocalBounds();
-        if (bounds.getWidth() > 0 && bounds.getHeight() > 0)
+        if (props.contains(statefulProp) && props[statefulProp])
         {
-            canvasImage = canvasImage.rescaled(bounds.getWidth(),
-                                               bounds.getHeight(),
-                                               juce::Graphics::highResamplingQuality);
+            //TODO: Fix image scalling for retina displays.
+            //      May require passing an optional scaleFactor
+            //      arg through to draw commands.
+            const auto bounds = getLocalBounds();
+            if (bounds.getWidth() > 0 && bounds.getHeight() > 0)
+            {
+                canvasImage = canvasImage.rescaled(bounds.getWidth(),
+                                                   bounds.getHeight(),
+                                                   juce::Graphics::highResamplingQuality);
+            }
         }
     }
 


### PR DESCRIPTION
case.

    We should probably investigate our "stateful" canvas component after
    this to ensure we don't have any giant performance holes. Worth
    noting that juce::Image::rescaled is a pretty slow thing should we
    rely on it again.