### PR TITLE
Made CMakeLists.txt CPM-compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,17 @@ project(reactjuce VERSION 0.1.0)
 # (practical to debug the plugin processor directly from your IDE)
 option(JUCE_BUILD_EXTRAS "Build JUCE Extras" OFF)
 
-
 # Change this option to set the JS Interpreter/Engine you wish to run React-JUCE against.
-set(REACTJUCE_JS_LIBRARY DUKTAPE CACHE STRING "The JS Engine to use: either HERMES or DUKTAPE")
+if (NOT DEFINED REACTJUCE_JS_LIBRARY)
+    set(REACTJUCE_JS_LIBRARY DUKTAPE CACHE STRING "The JS Engine to use: either HERMES or DUKTAPE")
+endif()
 
+# Set this to OFF in your CPMAddPackage if you're including this as a library.
+option(REACTJUCE_INCLUDE_JUCE "" ON)
 
-add_subdirectory(ext/juce)
+if (REACTJUCE_INCLUDE_JUCE)
+  add_subdirectory(ext/juce)
+endif()
 
 # Adding any custom modules you might have:
 juce_add_module(react_juce)
@@ -49,6 +54,11 @@ elseif (REACTJUCE_JS_LIBRARY STREQUAL "DUKTAPE")
     )
 endif()
 
-# If you want to create new projects, you can init them in the examples folder
-# and add them here with the add_subdirectory command
-add_subdirectory(examples/GainPlugin)
+# Set this to OFF in your CPMAddPackage if you're including this as a library.
+option(REACTJUCE_BUILD_EXAMPLES ON)
+
+if (REACTJUCE_BUILD_EXAMPLES)
+    # If you want to create new projects, you can init them in the examples folder
+    # and add them here with the add_subdirectory command
+    add_subdirectory(examples/GainPlugin)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT DEFINED REACTJUCE_JS_LIBRARY)
 endif()
 
 # Set this to OFF in your CPMAddPackage if you're including this as a library.
-option(REACTJUCE_INCLUDE_JUCE "" ON)
+option(REACTJUCE_INCLUDE_JUCE "Include JUCE" ON)
 
 if (REACTJUCE_INCLUDE_JUCE)
   add_subdirectory(ext/juce)
@@ -55,7 +55,7 @@ elseif (REACTJUCE_JS_LIBRARY STREQUAL "DUKTAPE")
 endif()
 
 # Set this to OFF in your CPMAddPackage if you're including this as a library.
-option(REACTJUCE_BUILD_EXAMPLES ON)
+option(REACTJUCE_BUILD_EXAMPLES "Build examples" ON)
 
 if (REACTJUCE_BUILD_EXAMPLES)
     # If you want to create new projects, you can init them in the examples folder

--- a/docs/guides/Getting_Started.md
+++ b/docs/guides/Getting_Started.md
@@ -12,9 +12,52 @@ To get started with React-JUCE, you'll first need to install a few dependencies:
 - Xcode10.2+ (MacOS)
 - Visual Studio 2017+ (Windows)
 
-Once you have the dependencies installed, we need to clone the React-JUCE repository
-itself. React-JUCE's git repository contains necessary submodules, so we'll need to
-collect those as well, which we can do one of two ways:
+## Including react-juce as a library with CPM
+
+If you want to use react-juce as a library in your CMake project, you can include it
+automatically with CPM.
+
+```
+# Set js library to "DUKTAPE" or "HERMES
+set(REACTJUCE_JS_LIBRARY "HERMES")
+CPMAddPackage(
+  NAME react_juce
+  GITHUB_REPOSITORY nick-thompson/react-juce
+  GIT_TAG origin/master
+  OPTIONS 
+    "REACTJUCE_INCLUDE_JUCE OFF" "REACTJUCE_BUILD_EXAMPLES OFF"
+)
+```
+
+Then you'll want to add `react_juce` to the `target_link_libraries` call for your
+plugin or app, like so:
+
+```
+target_link_libraries(${TargetName} PRIVATE
+  # Other dependencies here
+  # ...
+  react_juce)
+```
+
+After that, you'll want to include the react-juce headers in the source file where
+you intend to inject some react-juce behavior.
+
+```
+#include "react_juce.h"
+```
+
+After that, the `reactjuce` namespace will be available, so you can use classes like
+`reactjuce::GenericEditor`. The gain plugin included in this repo has some example
+code that should help you understand how to plug some react code into your plugin or
+app.
+
+
+## Building this repo
+
+If you need to build this repo yourself or want to run the examples, you'll need to
+clone the React-JUCE repository itself. React-JUCE's git repository contains
+necessary submodules, so you'll need to collect those as well, which we can do one
+of two ways:
 
 ```bash
 $ git clone --recurse-submodules git@github.com:nick-thompson/react-juce.git


### PR DESCRIPTION
Implemented the fix detailed in https://github.com/nick-thompson/react-juce/issues/253

In summary this PR:

* Makes it possible to include react-juce with CPM
* Makes it possible to modify `REACTJUCE_JS_LIBRARY` from client code
* Makes building JUCE optional
* Makes building the example optional
* Documents all of these changes