### PR TITLE
Fix mac build with strict warnings

### DIFF
--- a/react_juce/core/TextShadowView_Yoga.cpp
+++ b/react_juce/core/TextShadowView_Yoga.cpp
@@ -7,27 +7,30 @@ namespace reactjuce
     /** We use this method to measure the size of a given string so that the
      *  text container knows what size to take.
      */
-    YGSize measureTextNode(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
+    namespace
     {
-        juce::ignoreUnused(widthMode);
-        juce::ignoreUnused(height);
-        juce::ignoreUnused(heightMode);
+        YGSize measureTextNode(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
+        {
+            juce::ignoreUnused(widthMode);
+            juce::ignoreUnused(height);
+            juce::ignoreUnused(heightMode);
 
-        auto context = reinterpret_cast<TextShadowView*>(YGNodeGetContext(node));
-        auto view = dynamic_cast<TextView*>(context->getAssociatedView());
+            auto context = reinterpret_cast<TextShadowView*>(YGNodeGetContext(node));
+            auto view = dynamic_cast<TextView*>(context->getAssociatedView());
 
-        jassert (view != nullptr);
+            jassert (view != nullptr);
 
-        // TODO: This is a bit of an oversimplification. We have a YGMeasureMode which
-        // is one of three things, "undefined", "exact", or "at-most." Here we're kind of
-        // just ignoring that, and in cases like `white-space: nowrap;` we want to ignore it,
-        // but it would probably be good to get specific for each case.
-        // See https://github.com/facebook/yoga/pull/576/files
-        auto tl = view->getTextLayout(width);
+            // TODO: This is a bit of an oversimplification. We have a YGMeasureMode which
+            // is one of three things, "undefined", "exact", or "at-most." Here we're kind of
+            // just ignoring that, and in cases like `white-space: nowrap;` we want to ignore it,
+            // but it would probably be good to get specific for each case.
+            // See https://github.com/facebook/yoga/pull/576/files
+            auto tl = view->getTextLayout(width);
 
-        return { tl.getWidth(), tl.getHeight() };
+            return { tl.getWidth(), tl.getHeight() };
+        }
     }
-
+    
     //==============================================================================
     class TextShadowView::TextShadowViewPimpl
     {


### PR DESCRIPTION
@nick-thompson, this is rearing it's head with our warning settings.  Complains when you have no previous declaration of the non-static function inside the react_juce namespace. Moving into anonymous namespace resolves. 