### PR TITLE
Improve border properties support

### DIFF
--- a/packages/react-juce/src/lib/Backend.ts
+++ b/packages/react-juce/src/lib/Backend.ts
@@ -22,6 +22,78 @@ const cssPropsMap = allCssProps
   .filter((s) => !s.startsWith("-") && s.includes("-"))
   .reduce((acc, v) => Object.assign(acc, { [camelCase(v)]: v }), {});
 
+// known CSS border styles for React Native
+const cssBorderStyles = ["dotted", "dashed", "solid"];
+
+// Parse combination border properties.
+function parseBorderSideProp(name: string, val: string | number, info: object) {
+  invariant(
+    typeof val === "string" || typeof val === "number",
+    name + " must be a string or a number"
+  );
+
+  if (typeof val === "number")
+  {
+    info[0] = info[1] = info[2] = info[3] = val;
+    return;
+  }
+
+  const values = val.split(" ");
+
+  invariant(
+    values.length >= 1 && values.length <= 4,
+    "border-" + name + " should be a space separated string with 1 to 4 values."
+  );
+
+  switch (values.length) {
+    case 1:
+      info[0] = info[1] = info[2] = info[3] = values[0];
+      break;
+    case 2:
+      info[0] = info[2] = values[0];
+      info[1] = info[3] = values[1];
+      break;
+    case 3:
+      info[0] = values[0];
+      info[1] = info[3] = values[1];
+      info[2] = values[2];
+      break;
+    default:
+      info[0] = values[0];
+      info[1] = values[1];
+      info[2] = values[2];
+      info[3] = values[3];
+  }
+}
+
+function parseBorderProp(val: string, info: object) {
+  /*
+    Parameters can be in any order. So we need to recognised
+    which might be which.
+  */
+  const numbers = "0123456789.-+";
+  const values = val.split(" ");
+
+  invariant(
+    values.length >= 1 && values.length <= 3,
+    "border should be a space separated string with 1 to 3 values."
+  );
+
+  const bs = info["style"];
+  const bw = info["width"];
+  const bc = info["color"];
+
+  for (val of values) {
+    if (cssBorderStyles.includes(val)) {
+      bs[0] = bs[1] = bs[2] = bs[3] = val;
+    } else if (numbers.includes(val.charAt(0))) {
+      bw[0] = bw[1] = bw[2] = bw[3] = val;
+    } else {
+      bc[0] = bc[1] = bc[2] = bc[3] = val;
+    }
+  }
+}
+
 export class ViewInstance {
   private _id: string;
   private _type: string;
@@ -32,6 +104,12 @@ export class ViewInstance {
   constructor(id: string, type: string, props?: any, parent?: ViewInstance) {
     this._id = id;
     this._type = type;
+    this._border = {
+      "width":  [0, 0, 0, 0],
+      "radius": ["0", "0", "0", "0"],
+      "color":  ["", "", "", ""],
+      "style":  ["solid", "solid", "solid", "solid"],
+    };
     this._children = [];
     this._props = props;
     this._parent = parent;
@@ -144,6 +222,100 @@ export class ViewInstance {
         NativeMethods.setViewProperty(this._id, k, v);
       return;
     }
+
+    // Look for border properties and translate into our internal
+    // border-info property.
+    if (propKey.startsWith("border")) {
+      let gotBorderProp : boolean = true;
+
+      switch (propKey) {
+        case "border":
+          parseBorderProp(value, this._border);
+          break;
+
+        case "border-color":
+          parseBorderSideProp("color", value, this._border["color"]);
+          break;
+        case "border-top-color":
+          this._border["color"][0] = value;
+          break;
+        case "border-right-color":
+          this._border["color"][1] = value;
+          break;
+        case "border-bottom-color":
+          this._border["color"][2] = value;
+          break;
+        case "border-left-color":
+          this._border["color"][3] = value;
+          break;
+
+        case "border-radius":
+          parseBorderSideProp("radius", value, this._border["radius"]);
+          break;
+        case "border-top-left-radius":
+          this._border["radius"][0] = value;
+          break;
+        case "border-top-right-radius":
+          this._border["radius"][1] = value;
+          break;
+        case "border-bottom-right-radius":
+          this._border["radius"][2] = value;
+          break;
+        case "border-bottom-left-radius":
+          this._border["radius"][3] = value;
+          break;
+
+        case "border-style":
+          parseBorderSideProp("style", value, this._border["style"]);
+          break;
+        case "border-top-style":
+          this._border["style"][0] = value;
+          break;
+        case "border-right-style":
+          this._border["style"][1] = value;
+          break;
+        case "border-bottom-style":
+          this._border["style"][2] = value;
+          break;
+        case "border-left-style":
+          this._border["style"][3] = value;
+          break;
+
+        case "border-width":
+          parseBorderSideProp("width", value, this._border["width"]);
+          break;
+        case "border-top-width":
+          this._border["width"][0] = value;
+          break;
+        case "border-right-width":
+          this._border["width"][1] = value;
+          break;
+        case "border-bottom-width":
+          this._border["width"][2] = value;
+          break;
+        case "border-left-width":
+          this._border["width"][3] = value;
+          break;
+
+        default:
+          gotBorderProp = false;
+          break;
+      }
+
+      invariant(
+        cssBorderStyles.includes(this._border["style"][0]) &&
+        cssBorderStyles.includes(this._border["style"][1]) &&
+        cssBorderStyles.includes(this._border["style"][2]) &&
+        cssBorderStyles.includes(this._border["style"][3]),
+        "unknown border-style."
+      );
+
+      if (gotBorderProp) {
+        propKey = "border-info";
+        value = this._border;
+      }
+    }
+
     //@ts-ignore
     return NativeMethods.setViewProperty(
       this._id,

--- a/react_juce/core/View.cpp
+++ b/react_juce/core/View.cpp
@@ -328,12 +328,14 @@ namespace reactjuce
             float widths[LEFT + 1];
             float radii[LEFT + 1];
             juce::StringRef colors[LEFT + 1];
+            juce::StringRef styles[LEFT + 1];
 
             for (int edgeNo = TOP; edgeNo <= LEFT; ++edgeNo)
             {
-                widths[edgeNo] = props[borderInfoProp]["width"][edgeNo];
                 colors[edgeNo] = props[borderInfoProp]["color"][edgeNo].toString();
                 radii[edgeNo] = getResolvedFloatProperty(props[borderInfoProp]["radius"][edgeNo], minWidthHeight);
+                styles[edgeNo] = props[borderInfoProp]["style"][edgeNo].toString();
+                widths[edgeNo] = props[borderInfoProp]["width"][edgeNo];
             }
 
             // Path and stroke the border edges.
@@ -358,7 +360,21 @@ namespace reactjuce
 
                 auto color = juce::Colour::fromString(colors[edgeNo]);
                 g.setColour(color);
-                g.strokePath(p, juce::PathStrokeType(width));
+                auto strokeType = juce::PathStrokeType(width);
+                juce::Path strokedPath;
+                if (styles[edgeNo] == juce::String("dotted"))
+                {
+                    float dash[] = { 1.0, 1.0 };
+                    strokeType.createDashedStroke(strokedPath, p, dash, 2);
+                }
+                else if (styles[edgeNo] == juce::String("dashed"))
+                {
+                    float dash[] = { 4.0, 1.0 };
+                    strokeType.createDashedStroke(strokedPath, p, dash, 2);
+                }
+                else
+                    strokeType.createStrokedPath(strokedPath, p);
+                g.fillPath(strokedPath);
             }
 
             // Path the clip region.

--- a/react_juce/core/View.cpp
+++ b/react_juce/core/View.cpp
@@ -45,8 +45,6 @@ namespace {
     {
         juce::Path res;
         const auto Pi = juce::MathConstants<float>::pi;
-        juce::Point<float> lineStart;
-        juce::Point<float> lineEnd;
 
         if (startRadius > 0)
         {
@@ -82,21 +80,23 @@ namespace {
                 break;
             }
         }
-
-        switch(edge)
+        else
         {
-        case BorderEdge::TOP:
-            lineStart = juce::Point<float>(prevWidth + startRadius, width - pathOffset);
-            break;
-        case BorderEdge::RIGHT:
-            lineStart = juce::Point<float>(borderWidth - width + pathOffset, prevWidth + startRadius);
-            break;
-        case BorderEdge::BOTTOM:
-            lineStart = juce::Point<float>(borderWidth - prevWidth - startRadius, borderHeight - width + pathOffset);
-            break;
-        case BorderEdge::LEFT:
-            lineStart = juce::Point<float>(width - pathOffset, borderHeight - prevWidth - startRadius);
-            break;
+            switch(edge)
+            {
+            case BorderEdge::TOP:
+                res.startNewSubPath(prevWidth + startRadius, width - pathOffset);
+                break;
+            case BorderEdge::RIGHT:
+                res.startNewSubPath(borderWidth - width + pathOffset, prevWidth + startRadius);
+                break;
+            case BorderEdge::BOTTOM:
+                res.startNewSubPath(borderWidth - prevWidth - startRadius, borderHeight - width + pathOffset);
+                break;
+            case BorderEdge::LEFT:
+                res.startNewSubPath(width - pathOffset, borderHeight - prevWidth - startRadius);
+                break;
+            }
         }
 
         if (endRadius > 0)
@@ -107,33 +107,25 @@ namespace {
                 res.addCentredArc(borderWidth - nextWidth - endRadius, width + endRadius,
                                   endRadius + pathOffset, endRadius + pathOffset,
                                   0,
-                                  0, 0.25 * Pi,
-                                  true);
-                lineEnd = juce::Point<float>(borderWidth - prevWidth - endRadius, width - pathOffset);
+                                  0, 0.25 * Pi);
                 break;
             case BorderEdge::RIGHT:
                 res.addCentredArc(borderWidth - width - endRadius, borderHeight - nextWidth - endRadius,
                                   endRadius + pathOffset, endRadius + pathOffset,
                                   0,
-                                  0.5 * Pi, 0.75 * Pi,
-                                  true);
-                lineEnd = juce::Point<float>(borderWidth - width + pathOffset, borderHeight - nextWidth - endRadius);
+                                  0.5 * Pi, 0.75 * Pi);
                 break;
             case BorderEdge::BOTTOM:
                 res.addCentredArc(nextWidth + endRadius, borderHeight - width - endRadius,
                                   endRadius + pathOffset, endRadius + pathOffset,
                                   0,
-                                  Pi, 1.25 * Pi,
-                                  true);
-                lineEnd = juce::Point<float>(width + endRadius, borderHeight - width + pathOffset);
+                                  Pi, 1.25 * Pi);
                 break;
             case BorderEdge::LEFT:
                 res.addCentredArc(width + endRadius, nextWidth + endRadius,
                                   endRadius + pathOffset, endRadius + pathOffset,
                                   0,
-                                  1.5 * Pi, 1.75 * Pi,
-                                  true);
-                lineEnd = juce::Point<float>(width - pathOffset, nextWidth + endRadius);
+                                  1.5 * Pi, 1.75 * Pi);
                 break;
             }
         }
@@ -147,22 +139,19 @@ namespace {
             switch(edge)
             {
             case BorderEdge::TOP:
-                lineEnd = juce::Point<float>(borderWidth, width - pathOffset);
+                res.lineTo(borderWidth, width - pathOffset);
                 break;
             case BorderEdge::RIGHT:
-                lineEnd = juce::Point<float>(borderWidth - width + pathOffset, borderHeight);
+                res.lineTo(borderWidth - width + pathOffset, borderHeight);
                 break;
             case BorderEdge::BOTTOM:
-                lineEnd = juce::Point<float>(0, borderHeight - width + pathOffset);
+                res.lineTo(0, borderHeight - width + pathOffset);
                 break;
             case BorderEdge::LEFT:
-                lineEnd = juce::Point<float>(width - pathOffset, 0);
+                res.lineTo(width - pathOffset, 0);
                 break;
             }
         }
-
-        res.startNewSubPath(lineStart);
-        res.lineTo(lineEnd);
 
         return res;
     }

--- a/react_juce/core/View.cpp
+++ b/react_juce/core/View.cpp
@@ -51,29 +51,37 @@ namespace {
             switch(edge)
             {
             case BorderEdge::TOP:
-                res.addCentredArc(prevWidth + startRadius, width + startRadius,
-                                  startRadius + pathOffset, startRadius + pathOffset,
+                res.addCentredArc(juce::jmin(prevWidth + startRadius, borderWidth / 2),
+                                  juce::jmin(width + startRadius, borderHeight / 2),
+                                  juce::jmin(startRadius, borderWidth / 2 - pathOffset) + pathOffset,
+                                  juce::jmin(startRadius, borderHeight / 2 - pathOffset) + pathOffset,
                                   0,
                                   1.75 * Pi, 2.0 * Pi,
                                   true);
                 break;
             case BorderEdge::RIGHT:
-                res.addCentredArc(borderWidth - width - startRadius, prevWidth + startRadius,
-                                  startRadius + pathOffset, startRadius + pathOffset,
+                res.addCentredArc(juce::jmax(borderWidth - width - startRadius, borderWidth / 2),
+                                  juce::jmin(prevWidth + startRadius, borderHeight / 2),
+                                  juce::jmin(startRadius, borderWidth / 2 - pathOffset) + pathOffset,
+                                  juce::jmin(startRadius, borderHeight / 2 - pathOffset) + pathOffset,
                                   0,
                                   0.25 * Pi, 0.5 * Pi,
                                   true);
                 break;
             case BorderEdge::BOTTOM:
-                res.addCentredArc(borderWidth - prevWidth - startRadius, borderHeight - width  - startRadius,
-                                  startRadius + pathOffset, startRadius + pathOffset,
+                res.addCentredArc(juce::jmax(borderWidth - prevWidth - startRadius, borderWidth / 2),
+                                  juce::jmax(borderHeight - width  - startRadius, borderHeight / 2),
+                                  juce::jmin(startRadius, borderWidth / 2 - pathOffset) + pathOffset,
+                                  juce::jmin(startRadius, borderHeight / 2 - pathOffset) + pathOffset,
                                   0,
                                   0.75 * Pi, Pi,
                                   true);
                 break;
             case BorderEdge::LEFT:
-                res.addCentredArc(width + startRadius, borderHeight - prevWidth - startRadius,
-                                  startRadius + pathOffset, startRadius + pathOffset,
+                res.addCentredArc(juce::jmin(width + startRadius, borderWidth / 2),
+                                  juce::jmax(borderHeight - prevWidth - startRadius, borderHeight / 2),
+                                  juce::jmin(startRadius, borderWidth / 2 - pathOffset) + pathOffset,
+                                  juce::jmin(startRadius, borderHeight / 2 - pathOffset) + pathOffset,
                                   0,
                                   1.25 * Pi, 1.5 * Pi,
                                   true);
@@ -104,26 +112,34 @@ namespace {
             switch(edge)
             {
             case BorderEdge::TOP:
-                res.addCentredArc(borderWidth - nextWidth - endRadius, width + endRadius,
-                                  endRadius + pathOffset, endRadius + pathOffset,
+                res.addCentredArc(juce::jmax(borderWidth - nextWidth - endRadius, borderWidth / 2),
+                                  juce::jmin(width + endRadius, borderHeight / 2),
+                                  juce::jmin(endRadius, borderWidth / 2 - pathOffset) + pathOffset,
+                                  juce::jmin(endRadius, borderHeight / 2 - pathOffset) + pathOffset,
                                   0,
                                   0, 0.25 * Pi);
                 break;
             case BorderEdge::RIGHT:
-                res.addCentredArc(borderWidth - width - endRadius, borderHeight - nextWidth - endRadius,
-                                  endRadius + pathOffset, endRadius + pathOffset,
+                res.addCentredArc(juce::jmax(borderWidth - width - endRadius, borderWidth / 2),
+                                  juce::jmax(borderHeight - nextWidth - endRadius, borderHeight / 2),
+                                  juce::jmin(endRadius, borderWidth / 2 - pathOffset) + pathOffset,
+                                  juce::jmin(endRadius, borderHeight / 2 - pathOffset) + pathOffset,
                                   0,
                                   0.5 * Pi, 0.75 * Pi);
                 break;
             case BorderEdge::BOTTOM:
-                res.addCentredArc(nextWidth + endRadius, borderHeight - width - endRadius,
-                                  endRadius + pathOffset, endRadius + pathOffset,
+                res.addCentredArc(juce::jmin(nextWidth + endRadius, borderWidth / 2),
+                                  juce::jmax(borderHeight - width - endRadius, borderHeight / 2),
+                                  juce::jmin(endRadius, borderWidth / 2 - pathOffset) + pathOffset,
+                                  juce::jmin(endRadius, borderHeight / 2 - pathOffset) + pathOffset,
                                   0,
                                   Pi, 1.25 * Pi);
                 break;
             case BorderEdge::LEFT:
-                res.addCentredArc(width + endRadius, nextWidth + endRadius,
-                                  endRadius + pathOffset, endRadius + pathOffset,
+                res.addCentredArc(juce::jmin(width + endRadius, borderWidth / 2),
+                                  juce::jmin(nextWidth + endRadius, borderHeight / 2),
+                                  juce::jmin(endRadius, borderWidth / 2 - pathOffset) + pathOffset,
+                                  juce::jmin(endRadius, borderHeight / 2 - pathOffset) + pathOffset,
                                   0,
                                   1.5 * Pi, 1.75 * Pi);
                 break;

--- a/react_juce/core/View.h
+++ b/react_juce/core/View.h
@@ -38,10 +38,8 @@ namespace reactjuce
 
         static const inline juce::Identifier backgroundColorProp      = "background-color";
 
-        static const inline juce::Identifier borderColorProp          = "border-color";
+        static const inline juce::Identifier borderInfoProp           = "border-info";
         static const inline juce::Identifier borderPathProp           = "border-path";
-        static const inline juce::Identifier borderRadiusProp         = "border-radius";
-        static const inline juce::Identifier borderWidthProp          = "border-width";
 
         //==============================================================================
         View() = default;
@@ -64,9 +62,6 @@ namespace reactjuce
         void setFloatBounds (juce::Rectangle<float> bounds);
 
         //==============================================================================
-        /** Resolves a property to a specific point value or 0 if not present. */
-        float getResolvedLengthProperty (const juce::String& name, float axisLength);
-
         /** Override the default Component method with default paint behaviors. */
         void paint (juce::Graphics& g) override;
 


### PR DESCRIPTION
Break border drawing into separate drawing of top/right/bottom/left border components and add properties for border-(top|right|bottom|left)-(color|style-width) and border-(top-left|top-right|bottom-right|bottom-left)-radius. Also add styles 'dotted' and 'dashed'.

Fixes #143