### PR TITLE
Document TextInput by moving inline class docs

### DIFF
--- a/docs/components/TextInput.md
+++ b/docs/components/TextInput.md
@@ -1,0 +1,66 @@
+
+TextInput component imitates web's `<input type="text">`.
+https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text
+So it supports props like `placeholder`, `maxlength`, `onInput`, etc...
+
+TextInput also supports React's controlled components model:
+https://reactjs.org/docs/uncontrolled-components.html.
+If the user supplies a `value` prop,
+then it never renders anything into that text editor other than
+the string supplied by that `value` prop.
+
+## Example
+
+```js
+import React, { Component } from "react";
+
+import { Text, TextInput, View } from "react-juce";
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this._onInput = this._onInput.bind(this);
+
+    this.state = {
+      textValue: "",
+    };
+  }
+
+  _onInput(event) {
+    console.log(`onInput: ${event.value}`);
+    this.setState({ textValue: event.value });
+  }
+
+  render() {
+    return (
+      <View>
+        <TextInput
+          value={this.state.textValue}
+          placeholder="init message"
+          onInput={this._onInput}
+          {...styles.text_input}
+        />
+      </View>
+    );
+  }
+}
+
+const styles = {
+  text_input: {
+    backgroundColor: "ff303030",
+    color: "ff66FDCF",
+    fontSize: 15.0,
+    fontFamily: "Menlo",
+    fontStyle: Text.FontStyleFlags.bold,
+    "placeholder-color": "ffAAAAAA",
+    height: 30,
+    width: 200,
+  },
+};
+
+export default App;
+```
+
+## Props
+
+**TODO**: Document props. See [the class](https://github.com/nick-thompson/react-juce/blob/master/packages/react-juce/src/components/TextInput.tsx#L11) for props in the meantime.

--- a/docs/components/TextInput.md
+++ b/docs/components/TextInput.md
@@ -1,4 +1,3 @@
-
 TextInput component imitates web's `<input type="text">`.
 https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text
 So it supports props like `placeholder`, `maxlength`, `onInput`, etc...

--- a/packages/react-juce/src/components/TextInput.tsx
+++ b/packages/react-juce/src/components/TextInput.tsx
@@ -33,71 +33,7 @@ export interface TextInputProps {
 }
 
 /**
- * TextInput component imitates web's `<input type="text">`.
- * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text
- * So it supports props like `placeholder`, `maxlength`, `onInput`, etc...
- *
- * TextInput also supports React's controlled components model:
- * https://reactjs.org/docs/uncontrolled-components.html.
- * If the user supplies a `value` prop,
- * then it never renders anything into that text editor other than
- * the string supplied by that `value` prop.
  */
 export function TextInput(props: PropsWithChildren<TextInputProps | any>) {
   return React.createElement("TextInput", props, props.children);
 }
-
-/*
-// ================================================
-// Example code
-
-import React, { Component } from "react";
-
-import { Text, TextInput, View } from "react-juce";
-
-class App extends Component {
-  constructor(props) {
-    super(props);
-    this._onInput = this._onInput.bind(this);
-
-    this.state = {
-      textValue: "",
-    };
-  }
-
-  _onInput(event) {
-    console.log(`onInput: ${event.value}`);
-    this.setState({ textValue: event.value });
-  }
-
-  render() {
-    return (
-      <View>
-        <TextInput
-          value={this.state.textValue}
-          placeholder="init message"
-          onInput={this._onInput}
-          {...styles.text_input}
-        />
-      </View>
-    );
-  }
-}
-
-const styles = {
-  text_input: {
-    backgroundColor: "ff303030",
-    color: "ff66FDCF",
-    fontSize: 15.0,
-    fontFamily: "Menlo",
-    fontStyle: Text.FontStyleFlags.bold,
-    "placeholder-color": "ffAAAAAA",
-    height: 30,
-    width: 200,
-  },
-};
-
-export default App;
-
-// ================================================
-*/

--- a/packages/react-juce/src/components/TextInput.tsx
+++ b/packages/react-juce/src/components/TextInput.tsx
@@ -32,8 +32,6 @@ export interface TextInputProps {
   onInput?: (e: InputEvent) => void;
 }
 
-/**
- */
 export function TextInput(props: PropsWithChildren<TextInputProps | any>) {
   return React.createElement("TextInput", props, props.children);
 }


### PR DESCRIPTION
Based on my brief experience, some of the props have non-standard behavior so putting of documenting them. I can return after I play around with it a bit.